### PR TITLE
GitHub Actions: run cargo-bloat on master

### DIFF
--- a/.github/workflows/cargo-bloat.yml
+++ b/.github/workflows/cargo-bloat.yml
@@ -1,6 +1,9 @@
 name: cargo-bloat
 
 on:
+  push:
+    branches:
+    - master
   pull_request:
     branches:
     - master


### PR DESCRIPTION
The cargo-bloat-action needs to run on master to record a bloat-snapshot
that can be compared against in PRs.